### PR TITLE
AO3-5283 Expand controller spec for the index action

### DIFF
--- a/factories/works.rb
+++ b/factories/works.rb
@@ -32,6 +32,11 @@ FactoryBot.define do
     factory :draft do
       posted { false }
     end
+
+    factory :spam_work do
+      spam { true }
+      spam_checked_at { Time.now }
+    end
   end
 
   factory :external_work do

--- a/spec/controllers/admin/spam_controller_spec.rb
+++ b/spec/controllers/admin/spam_controller_spec.rb
@@ -30,30 +30,69 @@ describe Admin::SpamController do
     context "when logged in as admin" do
       it "renders index template" do
         fake_login_admin(admin)
- 
+
         get :index
         expect(response).to render_template(:index)
       end
     end
 
     context "when spam exists" do
-      it "redirects to post with notice" do
-        spam_work = create(:work, spam: true)
+      let!(:unreviewed_work) { create(:spam_work).moderated_work }
+
+      let!(:reviewed_work) do
+        w = create(:spam_work)
+        w.moderated_work.mark_reviewed!
+        w.moderated_work
+      end
+
+      let!(:approved_work) do
+        w = create(:spam_work)
+        w.moderated_work.mark_reviewed!
+        w.moderated_work.mark_approved!
+        w.moderated_work
+      end
+
+      it "shows unreviewed and unapproved works by default" do
         fake_login_admin(admin)
+
         get :index
-        expect(response).to render_template(:index)
-        expect(assigns[:works]).to include(spam_work.moderated_work)
+
+        expect(assigns(:works)).to include(unreviewed_work)
+        expect(assigns(:works)).not_to include(reviewed_work)
+        expect(assigns(:works)).not_to include(approved_work)
+      end
+
+      it "shows reviewed and unapproved works when ?show=reviewed" do
+        fake_login_admin(admin)
+
+        get :index, params: { show: "reviewed" }
+
+        expect(assigns(:works)).to include(reviewed_work)
+        expect(assigns(:works)).not_to include(unreviewed_work)
+        expect(assigns(:works)).not_to include(approved_work)
+      end
+
+      it "shows approved works when ?show=approved" do
+        fake_login_admin(admin)
+
+        get :index, params: { show: "approved" }
+
+        expect(assigns(:works)).to include(approved_work)
+        expect(assigns(:works)).not_to include(unreviewed_work)
+        expect(assigns(:works)).not_to include(reviewed_work)
       end
     end
 
     context "when spam has been deleted" do
       it "fails horribly in manual testing but works fine here" do
-        deleted_work = create(:work, spam: true) 
+        deleted_work = create(:work, spam: true)
         deleted_work.destroy
         fake_login_admin(admin)
+
         get :index
+
         expect(response).to render_template(:index)
-        expect(assigns[:works]).not_to include(deleted_work.moderated_work)
+        expect(assigns(:works)).not_to include(deleted_work.moderated_work)
       end
     end
   end

--- a/spec/controllers/admin/spam_controller_spec.rb
+++ b/spec/controllers/admin/spam_controller_spec.rb
@@ -6,13 +6,13 @@ describe Admin::SpamController do
   include LoginMacros
   include RedirectExpectationHelper
 
-  describe "GET #index" do    
+  describe "GET #index" do
     let(:admin) { create(:admin) }
 
     context "when logged in as user" do
       it "redirects with notice" do
         fake_login
-        get :index, params: { reviewed: false, approved: false }
+        get :index
 
         it_redirects_to_with_notice(root_url, "I'm sorry, only an admin can look at that area")
       end
@@ -21,7 +21,7 @@ describe Admin::SpamController do
     context "when logged in as admin without correct authorization" do
       xit "redirects with notice" do
         fake_login_admin(admin)
-        get :index, params: { reviewed: false, approved: false }
+        get :index
 
         it_redirects_to_with_error(root_url, "Sorry, only an authorized admin can access the page you were trying to reach.")
       end
@@ -30,8 +30,8 @@ describe Admin::SpamController do
     context "when logged in as admin" do
       it "renders index template" do
         fake_login_admin(admin)
-        get :index, params: { reviewed: false, approved: false }
  
+        get :index
         expect(response).to render_template(:index)
       end
     end


### PR DESCRIPTION
I noticed that the existing specs used some params that aren't used in real life, so it made me want to test each branch of the "happy path".

* Fix params to reflect real life use case: no `show` param, `?show=approved`, or `?show=reviewed`.
* Test the presence of expected moderated works in various states (given that we're sticking with `assigns` for now, we're not too worried about Rails 6 deprecating them, and we'll use the gem that allows us to keep using `assigns`).
* Add a factory for `spam_work`, to simulate the case of a work marked as spam by the automated checker. The associated moderated work gets created by an `after_save` hook.